### PR TITLE
Allow specifying the disk.xfs to use, without breaking default behavior.

### DIFF
--- a/disk.c
+++ b/disk.c
@@ -71,7 +71,7 @@ int disk_read_block(xsm_word *page, int block_num)
 }
 
 /* Deallocate the disk */
-int disk_close()
+int disk_close(const char *filename)
 {
     int result;
 
@@ -79,7 +79,7 @@ int disk_close()
     fclose(_file);
 
     /* Commit changes to disk */
-    _file = fopen(XSM_DEFAULT_DISK, "w");
+    _file = fopen(filename, "w");
     result = fwrite(_disk_mem_copy, 1, _mem_size, _file);
     fclose(_file);
 

--- a/disk.h
+++ b/disk.h
@@ -11,6 +11,6 @@ int disk_init(const char *filename);
 int disk_write_page(xsm_word *page, int block_num);
 xsm_word *disk_get_block(int block);
 int disk_read_block(xsm_word *page, int block_num);
-int disk_close();
+int disk_close(const char *filename);
 
 #endif

--- a/simulator.c
+++ b/simulator.c
@@ -17,7 +17,7 @@ static const int XSM_CONSOLE_DURATION = XSM_SIMULATOR_DEFCONSOLE;
 int simulator_run()
 {
     // Ready
-    disk_init(XSM_DEFAULT_DISK);
+    disk_init(_options_disk_file);
 
     // Set
     if (!machine_init(&_options))
@@ -31,7 +31,7 @@ int simulator_run()
 
     // Finish
     machine_destroy();
-    disk_close();
+    disk_close(_options_disk_file);
     return XSM_SUCCESS;
 }
 
@@ -46,6 +46,7 @@ int simulator_parse_args(int argc, char **argv)
     _options.timer = XSM_TIMER_DURATION;
     _options.console = XSM_CONSOLE_DURATION;
     _options.disk = XSM_DISK_DURATION;
+    _options_disk_file = XSM_DEFAULT_DISK;
 
     while (argc > 0)
     {
@@ -102,6 +103,23 @@ int simulator_parse_args(int argc, char **argv)
                 exit(0);
             }
             _options.disk = val + 1;
+
+            argv++;
+            argc--;
+        }
+        else if (!strcmp(*argv, "--disk-file"))
+        {
+            argv++;
+            argc--;
+
+            FILE* f = fopen(*argv, "r");
+            if (f == NULL)
+            {
+                printf("Specified disk file can not be opened\n");
+                exit(0);
+            }
+            fclose(f);
+            _options_disk_file = *argv;
 
             argv++;
             argc--;

--- a/simulator.h
+++ b/simulator.h
@@ -13,6 +13,7 @@
 #define EXIT_FAILURE 1
 
 static xsm_options _options;
+static const char* _options_disk_file;
 
 int simulator_run();
 int simulator_parse_args(int argc, char **argv);


### PR DESCRIPTION
If --disk-file "path/to/disk.xfs" is specified, that disk will be loaded. 
Otherwise XSM_DEFAULT_DISK ("../xfs-interface/disk.xfs") is loaded.